### PR TITLE
Include `=disabled` in various AIP 203 instructions

### DIFF
--- a/docs/rules/0203/immutable.md
+++ b/docs/rules/0203/immutable.md
@@ -66,7 +66,7 @@ message Book {
   string name = 1;
 
   // Immutable. The title of the book.
-  // (-- api-linter: core::0203::immutable
+  // (-- api-linter: core::0203::immutable=disabled
   //     aip.dev/not-precedent: We need to do this because reasons. --)
   string title = 2;
 }

--- a/docs/rules/0203/input-only.md
+++ b/docs/rules/0203/input-only.md
@@ -66,7 +66,7 @@ message Book {
   string name = 1;
 
   // Input only. The password used to check out this book.
-  // (-- api-linter: core::0203::input-only
+  // (-- api-linter: core::0203::input-only=disabled
   //     aip.dev/not-precedent: We need to do this because reasons. --)
   string access_password = 2;
 }

--- a/docs/rules/0203/optional-conflict.md
+++ b/docs/rules/0203/optional-conflict.md
@@ -56,7 +56,7 @@ message Book {
   string name = 1;
 
   // Optional. The foreword for the book.
-  // (-- api-linter: core::0203::optional-conflict
+  // (-- api-linter: core::0203::optional-conflict=disabled
   //     aip.dev/not-precedent: We need to do this because reasons. --)
   string foreword = 2 [
     (google.api.field_behavior) = OPTIONAL,

--- a/docs/rules/0203/optional-consistency.md
+++ b/docs/rules/0203/optional-consistency.md
@@ -74,7 +74,7 @@ If you need to violate this rule, use a leading comment above the message.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto
-// (-- api-linter: core::0203::optional-consistency
+// (-- api-linter: core::0203::optional-consistency=disabled
 //     aip.dev/not-precedent: We need to do this because reasons. --)
 message Book {
   string name = 1;

--- a/docs/rules/0203/optional.md
+++ b/docs/rules/0203/optional.md
@@ -67,7 +67,7 @@ message Book {
   string name = 1;
 
   // Optional. The foreword for the book.
-  // (-- api-linter: core::0203::optional
+  // (-- api-linter: core::0203::optional=disabled
   //     aip.dev/not-precedent: We need to do this because reasons. --)
   string foreword = 2;
 }

--- a/docs/rules/0203/output-only.md
+++ b/docs/rules/0203/output-only.md
@@ -68,7 +68,7 @@ message Book {
   string name = 1;
 
   // Immutable. The title of the book.
-  // (-- api-linter: core::0203::output-only
+  // (-- api-linter: core::0203::output-only=disabled
   //     aip.dev/not-precedent: We need to do this because reasons. --)
   // Output only. When the book was published.
   google.protobuf.Timestamp publish_time = 2;


### PR DESCRIPTION
The instructions for disabling several AIP 203 rules currently lack "=disabled" at the end o the api-linter comment, which turns the statement into a no-op.